### PR TITLE
meson: Fix install-quiet after a clean

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3472,6 +3472,13 @@ installed_targets = [
   ecpg_targets,
 ]
 
+if oauth_flow_supported
+  installed_targets += [
+    libpq_oauth_so,
+    libpq_oauth_st,
+  ]
+endif
+
 # all targets that require building code
 all_built = [
   installed_targets,


### PR DESCRIPTION
libpq-oauth was missing from the installed_targets list, so

    $ ninja clean && ninja install-quiet

failed with the error message

    ERROR: File 'src/interfaces/libpq-oauth/libpq-oauth.a' could not be found

It seems a little odd to have to tell Meson what's missing, since it clearly knows how to build that missing file, but the "quiet" variant we've created must use --no-rebuild to avoid spawning concurrent ninja processes that would step on each other.

Reported-by: Andres Freund <andres@anarazel.de>
Backpatch-through: 18